### PR TITLE
Fix dev→main PR workflow head filter and null body guard

### DIFF
--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -18,11 +18,10 @@ jobs:
           MERGED_BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |
-          OWNER="${REPO%%/*}"
           EXISTING=$(gh pr list \
             --repo "$REPO" \
             --base main \
-            --head "${OWNER}:dev" \
+            --head dev \
             --json number,body)
 
           PR_NUMBER=$(echo "$EXISTING" | jq -r '.[0].number // empty')
@@ -35,9 +34,9 @@ jobs:
               --title "dev into main" \
               --body "- $MERGED_BRANCH"
           else
-            BODY=$(echo "$EXISTING" | jq -r '.[0].body')
+            BODY=$(echo "$EXISTING" | jq -r '.[0].body // ""')
 
-            if echo "$BODY" | grep -qF "- $MERGED_BRANCH"; then
+            if echo "$BODY" | grep -qFe "- $MERGED_BRANCH"; then
               echo "Branch already listed, skipping."
             else
               gh pr edit "$PR_NUMBER" \


### PR DESCRIPTION
Fixes the `dev-to-main-pr.yml` workflow to match the corrected version from other repos:

- Remove `--head "${OWNER}:dev"` (owner-prefixed head filter was preventing the existing PR from being found) — use plain `--head dev`
- Remove now-unused `OWNER` variable
- Add `// ""` null fallback in `jq` body extraction to avoid failures on a new empty PR
- Add `-e` flag to `grep` for safer pattern matching