### PR TITLE
Add Lint and Test badge and cross-repo suite badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # FazzToolsFrontend
 
 [![Deploy](https://github.com/joefarrelly/FazzToolsFrontend/actions/workflows/deploy.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsFrontend/actions/workflows/deploy.yml)
+[![Lint and Test](https://github.com/joefarrelly/FazzToolsFrontend/actions/workflows/lint.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsFrontend/actions/workflows/lint.yml)
+
+**API** [![Deploy](https://github.com/joefarrelly/FazzToolsAPI/actions/workflows/deploy.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsAPI/actions/workflows/deploy.yml) [![Lint and Test](https://github.com/joefarrelly/FazzToolsAPI/actions/workflows/lint.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsAPI/actions/workflows/lint.yml) | **Scraper** [![Lint](https://github.com/joefarrelly/FazzToolsScraper/actions/workflows/lint.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsScraper/actions/workflows/lint.yml) [![Release](https://github.com/joefarrelly/FazzToolsScraper/actions/workflows/release.yml/badge.svg)](https://github.com/joefarrelly/FazzToolsScraper/actions/workflows/release.yml)
 
 React frontend for **FazzTools** — a World of Warcraft companion app.
 


### PR DESCRIPTION
Adds the missing Lint and Test workflow badge for this repo, plus a cross-repo status row showing API and Scraper key pipeline badges.