### PR TITLE
Merge phase-2a-ui into dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,13 @@ src/
     KeybindTable.tsx    # Keybind detail table
     KeybindUpload.tsx   # .lua file upload form
     MenuBar.tsx         # Sidebar nav (includes SidebarLink, LoginLogout)
-    MountTable.tsx      # Mount accordion list
+    MountTable.tsx      # Mount icon-grid accordion (collected + toggle for uncollected)
     PageLayout.tsx      # Wraps Header + MenuBar sidebar + main content
-    PetTable.tsx        # Pet accordion list
+    PetTable.tsx        # Pet icon-grid accordion (collected + toggle for uncollected)
     ProfessionTable.tsx # Profession recipe accordion
   pages/            # One file per route
     Account.tsx
+    Achievement.tsx     # Achievements grouped by category; lazy-loads per-category on expand
     Auth.tsx
     AuthRedirect.tsx
     Gear.tsx
@@ -41,6 +42,7 @@ src/
     Mount.tsx
     Pet.tsx
     Profession.tsx
+    Reputation.tsx      # Reputations grouped by alt → expansion; standing derived from raw value
     SingleGear.tsx
     SingleKeybind.tsx
     SingleProfession.tsx

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import Gear from 'pages/Gear';
 import Profession from 'pages/Profession';
 import Mount from 'pages/Mount';
 import Pet from 'pages/Pet';
+import Achievement from 'pages/Achievement';
+import Reputation from 'pages/Reputation';
 import Logout from 'pages/Logout';
 import SingleKeybind from 'pages/SingleKeybind';
 import SingleProfession from 'pages/SingleProfession';
@@ -28,6 +30,8 @@ function App() {
         <Route path="/profession" element={<Profession />} />
         <Route path="/mount" element={<Mount />} />
         <Route path="/pet" element={<Pet />} />
+        <Route path="/achievement" element={<Achievement />} />
+        <Route path="/reputation" element={<Reputation />} />
         <Route path="/logout" element={<Logout />} />
         <Route path="/keybind/:alt/:realm/:spec" element={<SingleKeybind />} />
         <Route path="/profession/:alt/:realm/:profession" element={<SingleProfession />} />

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -30,6 +30,8 @@ function LoginLogout() {
         <SidebarLink to="/profession">Profession</SidebarLink>
         <SidebarLink to="/mount">Mount</SidebarLink>
         <SidebarLink to="/pet">Pet</SidebarLink>
+        <SidebarLink to="/achievement">Achievements</SidebarLink>
+        <SidebarLink to="/reputation">Reputations</SidebarLink>
         <div className="mt-4 pt-4 border-t border-zinc-800">
           <SidebarLink to="/logout" danger>
             Logout

--- a/src/components/MountTable.tsx
+++ b/src/components/MountTable.tsx
@@ -2,28 +2,22 @@ import React, { useState } from 'react';
 import CollapsePanel from 'components/CollapsePanel';
 import type { CollectionEntry, MountItem } from 'types';
 
-interface MountTableRowProps {
-  alt: MountItem;
-  grayclass: string;
+interface MountIconProps {
+  mount: MountItem;
+  collected: boolean;
 }
 
-function MountTableRow({ alt, grayclass }: MountTableRowProps) {
+function MountIcon({ mount, collected }: MountIconProps) {
   return (
-    <div
-      className="flex items-center justify-between bg-zinc-800/50 border border-zinc-700 rounded mb-1 px-3 py-1"
-      style={{ width: '22rem' }}
-    >
-      <span className="text-sm text-zinc-200">{alt.name}</span>
-      <div className={grayclass}>
-        <img
-          src={alt.icon}
-          title={alt.name}
-          alt="No Icon"
-          width="48"
-          height="48"
-          className="rounded"
-        />
-      </div>
+    <div className={collected ? 'epic' : 'epic uncollected'}>
+      <img
+        src={mount.icon}
+        title={mount.name}
+        alt={mount.name}
+        width="48"
+        height="48"
+        className="rounded block"
+      />
     </div>
   );
 }
@@ -34,27 +28,53 @@ interface MountTableColProps {
 
 function MountTableCol({ alt }: MountTableColProps) {
   const [open, setOpen] = useState(false);
+  const [showUncollected, setShowUncollected] = useState(false);
+  const { collected_count, total_count, collected, uncollected } = alt[1];
+  const pct = total_count > 0 ? Math.round((collected_count / total_count) * 100) : 0;
+  const collectedMounts = collected as MountItem[];
+  const uncollectedMounts = uncollected as MountItem[];
+
   return (
-    <div>
+    <div className="mb-2">
       <button
-        className="text-left bg-zinc-800 hover:bg-zinc-700 text-zinc-200 px-4 py-2 rounded transition-colors text-sm flex items-center justify-between"
-        style={{ width: '22rem' }}
         type="button"
         onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
       >
-        <span>{alt[0]}</span>
-        <span className="text-zinc-400 text-xs">
-          {alt[1].collected_count}/{alt[1].total_count}
-        </span>
+        <span className="text-sm font-medium text-zinc-200">{alt[0]}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-zinc-400">
+            {collected_count}/{total_count}
+          </span>
+          <span className="text-xs text-amber-400 font-semibold">{pct}%</span>
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
       </button>
       <CollapsePanel open={open}>
-        <div className="pt-1 pl-1">
-          {(alt[1].collected as MountItem[]).map((row, index) => (
-            <MountTableRow alt={row} key={index} grayclass="epic" />
-          ))}
-          {(alt[1].uncollected as MountItem[]).map((row, index) => (
-            <MountTableRow alt={row} key={index} grayclass="epic uncollected" />
-          ))}
+        <div className="mt-2 pl-1">
+          <div className="flex flex-wrap gap-1">
+            {collectedMounts.map((m, i) => (
+              <MountIcon key={i} mount={m} collected />
+            ))}
+          </div>
+          {uncollectedMounts.length > 0 && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setShowUncollected(!showUncollected)}
+                className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors mb-1"
+              >
+                {showUncollected ? '▲ Hide' : '▼ Show'} {uncollectedMounts.length} uncollected
+              </button>
+              {showUncollected && (
+                <div className="flex flex-wrap gap-1">
+                  {uncollectedMounts.map((m, i) => (
+                    <MountIcon key={i} mount={m} collected={false} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </CollapsePanel>
     </div>
@@ -67,7 +87,7 @@ interface MountTableProps {
 
 function MountTable({ alts }: MountTableProps) {
   return (
-    <div className="space-y-1">
+    <div>
       {alts.map((col, index) => (
         <MountTableCol alt={col} key={index} />
       ))}

--- a/src/components/PetTable.tsx
+++ b/src/components/PetTable.tsx
@@ -2,30 +2,31 @@ import React, { useState } from 'react';
 import CollapsePanel from 'components/CollapsePanel';
 import type { CollectionEntry, PetItem } from 'types';
 
-interface PetTableRowProps {
-  alt: PetItem;
-  grayclass: string;
+interface PetIconProps {
+  pet: PetItem;
+  collected: boolean;
 }
 
-function PetTableRow({ alt, grayclass }: PetTableRowProps) {
+function PetIcon({ pet, collected }: PetIconProps) {
+  const img = (
+    <img
+      src={pet.icon}
+      title={pet.name}
+      alt={pet.name}
+      width="48"
+      height="48"
+      className="rounded block"
+    />
+  );
   return (
-    <div
-      className="flex items-center justify-between bg-zinc-800/50 border border-zinc-700 rounded mb-1 px-3 py-1"
-      style={{ width: '22rem' }}
-    >
-      <span className="text-sm text-zinc-200">{alt.name}</span>
-      <div className={grayclass}>
-        <a href={alt.link} target="_blank" rel="noopener noreferrer">
-          <img
-            src={alt.icon}
-            title={alt.name}
-            alt="No Icon"
-            width="48"
-            height="48"
-            className="rounded"
-          />
+    <div className={collected ? 'epic' : 'epic uncollected'}>
+      {pet.link ? (
+        <a href={pet.link} target="_blank" rel="noopener noreferrer">
+          {img}
         </a>
-      </div>
+      ) : (
+        img
+      )}
     </div>
   );
 }
@@ -36,40 +37,62 @@ interface PetTableColProps {
 
 function PetTableCol({ alt }: PetTableColProps) {
   const [open, setOpen] = useState(false);
+  const [showUncollected, setShowUncollected] = useState(false);
+  const { collected_count, total_count, collected, uncollected } = alt[1];
+  const pct = total_count > 0 ? Math.round((collected_count / total_count) * 100) : 0;
+  const collectedPets = collected as PetItem[];
+  const uncollectedPets = uncollected as PetItem[];
+
   return (
-    <div>
+    <div className="mb-2">
       <button
-        className="text-left bg-zinc-800 hover:bg-zinc-700 text-zinc-200 px-4 py-2 rounded transition-colors text-sm flex items-center justify-between"
-        style={{ width: '22rem' }}
         type="button"
         onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
       >
-        <span>{alt[0]}</span>
-        <span className="text-zinc-400 text-xs">
-          {alt[1].collected_count}/{alt[1].total_count}
-        </span>
+        <span className="text-sm font-medium text-zinc-200">{alt[0]}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-zinc-400">
+            {collected_count}/{total_count}
+          </span>
+          <span className="text-xs text-amber-400 font-semibold">{pct}%</span>
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
       </button>
       <CollapsePanel open={open}>
-        <div className="pt-1 pl-1">
-          {(alt[1].collected as PetItem[]).map((row, index) => (
-            <PetTableRow alt={row} key={index} grayclass="epic" />
-          ))}
-          {(alt[1].uncollected as PetItem[]).map((row, index) => (
-            <PetTableRow alt={row} key={index} grayclass="epic uncollected" />
-          ))}
+        <div className="mt-2 pl-1">
+          <div className="flex flex-wrap gap-1">
+            {collectedPets.map((p, i) => (
+              <PetIcon key={i} pet={p} collected />
+            ))}
+          </div>
+          {uncollectedPets.length > 0 && (
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setShowUncollected(!showUncollected)}
+                className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors mb-1"
+              >
+                {showUncollected ? '▲ Hide' : '▼ Show'} {uncollectedPets.length} uncollected
+              </button>
+              {showUncollected && (
+                <div className="flex flex-wrap gap-1">
+                  {uncollectedPets.map((p, i) => (
+                    <PetIcon key={i} pet={p} collected={false} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </CollapsePanel>
     </div>
   );
 }
 
-interface PetTableProps {
-  alts: CollectionEntry[];
-}
-
-function PetTable({ alts }: PetTableProps) {
+function PetTable({ alts }: { alts: CollectionEntry[] }) {
   return (
-    <div className="space-y-1">
+    <div>
       {alts.map((col, index) => (
         <PetTableCol alt={col} key={index} />
       ))}

--- a/src/pages/Achievement.tsx
+++ b/src/pages/Achievement.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import CollapsePanel from 'components/CollapsePanel';
+import LoadingSpinner from 'components/LoadingSpinner';
+import PageLayout from 'components/PageLayout';
+import { cookies } from 'cookies';
+import { config } from 'Constants';
+import type { AchievementEntry } from 'types';
+
+interface CategorySummary {
+  category_name: string;
+  count: number;
+  points: number;
+}
+
+const CATEGORY_ORDER = [
+  'Character',
+  'Quests',
+  'Exploration',
+  'Player vs. Player',
+  'Dungeons & Raids',
+  'Professions',
+  'Reputation',
+  'World Events',
+  'Pet Battles',
+  'Collections',
+  'Expansion Features',
+];
+
+function categorySort(a: string, b: string): number {
+  const ai = CATEGORY_ORDER.indexOf(a);
+  const bi = CATEGORY_ORDER.indexOf(b);
+  if (ai === -1 && bi === -1) return a.localeCompare(b);
+  if (ai === -1) return 1;
+  if (bi === -1) return -1;
+  return ai - bi;
+}
+
+interface CategoryPanelProps {
+  summary: CategorySummary;
+  userId: string;
+}
+
+function CategoryPanel({ summary, userId }: CategoryPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [achievements, setAchievements] = useState<AchievementEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [fetched, setFetched] = useState(false);
+
+  async function handleOpen() {
+    const next = !open;
+    setOpen(next);
+    if (next && !fetched) {
+      setLoading(true);
+      try {
+        const res = await axios.get(config.url.API_URL + '/api/profile/altachievements/', {
+          params: { user: userId, category: summary.category_name },
+        });
+        setAchievements(res.data as AchievementEntry[]);
+      } finally {
+        setLoading(false);
+        setFetched(true);
+      }
+    }
+  }
+
+  return (
+    <div className="mb-2">
+      <button
+        type="button"
+        onClick={() => void handleOpen()}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
+      >
+        <span className="text-sm font-medium text-zinc-200">{summary.category_name}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-zinc-400">{summary.count} earned</span>
+          <span className="text-xs text-amber-400 font-semibold">
+            {summary.points.toLocaleString()} pts
+          </span>
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
+      </button>
+      <CollapsePanel open={open}>
+        <div className="mt-1 pl-1">
+          {loading && (
+            <div className="py-3 px-3">
+              <LoadingSpinner />
+            </div>
+          )}
+          {!loading && fetched && (
+            <div className="space-y-1">
+              {achievements.map((a) => (
+                <div
+                  key={a.achievement}
+                  className="flex items-center justify-between bg-zinc-800/50 border border-zinc-700/50 rounded px-3 py-2"
+                >
+                  <span className="text-sm text-zinc-200">{a.achievement_name}</span>
+                  <span className="text-xs text-amber-400/80 font-medium ml-4 shrink-0">
+                    {a.achievement_points} pts
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CollapsePanel>
+    </div>
+  );
+}
+
+function Achievement() {
+  const [summary, setSummary] = useState<CategorySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const userId = cookies.get<string>('userid') ?? '';
+
+  useEffect(() => {
+    async function getSummary() {
+      try {
+        const res = await axios.get(config.url.API_URL + '/api/profile/altachievements/', {
+          params: { user: userId, summary: 1 },
+        });
+        setSummary(res.data as CategorySummary[]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    getSummary();
+  }, [userId]);
+
+  const sorted = useMemo(
+    () => [...summary].sort((a, b) => categorySort(a.category_name, b.category_name)),
+    [summary]
+  );
+
+  const totalPoints = useMemo(() => summary.reduce((s, c) => s + c.points, 0), [summary]);
+
+  return (
+    <PageLayout title={`Achievements — ${totalPoints.toLocaleString()} pts`}>
+      {loading && <LoadingSpinner />}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {!loading && !error && sorted.length === 0 && (
+        <p className="text-zinc-500 text-sm">No achievements found. Run a scan first.</p>
+      )}
+      {!loading && !error && sorted.length > 0 && (
+        <div className="max-w-2xl">
+          {sorted.map((cat) => (
+            <CategoryPanel key={cat.category_name} summary={cat} userId={userId} />
+          ))}
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+
+export default Achievement;

--- a/src/pages/Logout.tsx
+++ b/src/pages/Logout.tsx
@@ -1,10 +1,14 @@
+import axios from 'axios';
 import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
+import { config } from 'Constants';
 import { cookies } from 'cookies';
 
 function Logout() {
   useEffect(() => {
-    cookies.remove('userid', { path: '/', sameSite: 'lax', secure: true });
+    axios.post(`${config.url.API_URL}/api/custom/logout/`).finally(() => {
+      cookies.remove('userid', { path: '/', sameSite: 'lax', secure: true });
+    });
   });
   return <Navigate to="/" />;
 }

--- a/src/pages/Mount.tsx
+++ b/src/pages/Mount.tsx
@@ -29,8 +29,11 @@ function Mount() {
   }, []);
 
   const countData = data.slice(-3);
+  const collected = countData[0]?.[0] ?? '';
+  const total = countData[2]?.[0] ?? '';
+  const pct = total && collected ? Math.round((Number(collected) / Number(total)) * 100) : null;
   return (
-    <PageLayout title={`Mount ${countData[0]?.[0] ?? ''}/${countData[2]?.[0] ?? ''}`}>
+    <PageLayout title={`Mounts — ${collected}/${total}${pct !== null ? ` (${pct}%)` : ''}`}>
       {loading && <LoadingSpinner />}
       {error && <p className="text-red-400 text-sm">{error}</p>}
       {!loading && !error && <MountTable alts={data.slice(0, -3)} />}

--- a/src/pages/Pet.tsx
+++ b/src/pages/Pet.tsx
@@ -29,8 +29,11 @@ function Pet() {
   }, []);
 
   const countData = data.slice(-3);
+  const collected = countData[0]?.[0] ?? '';
+  const total = countData[2]?.[0] ?? '';
+  const pct = total && collected ? Math.round((Number(collected) / Number(total)) * 100) : null;
   return (
-    <PageLayout title={`Pet ${countData[0]?.[0] ?? ''}/${countData[2]?.[0] ?? ''}`}>
+    <PageLayout title={`Pets — ${collected}/${total}${pct !== null ? ` (${pct}%)` : ''}`}>
       {loading && <LoadingSpinner />}
       {error && <p className="text-red-400 text-sm">{error}</p>}
       {!loading && !error && <PetTable alts={data.slice(0, -3)} />}

--- a/src/pages/Reputation.tsx
+++ b/src/pages/Reputation.tsx
@@ -1,0 +1,286 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import CollapsePanel from 'components/CollapsePanel';
+import LoadingSpinner from 'components/LoadingSpinner';
+import PageLayout from 'components/PageLayout';
+import { cookies } from 'cookies';
+import { config } from 'Constants';
+import type { ReputationEntry } from 'types';
+
+// Derive standing from raw rep value using WoW's fixed thresholds.
+// standing_type stored in DB is currently unreliable (was pulling wrong field from API).
+function standingFromRaw(raw: number): string {
+  if (raw >= 42000) return 'Exalted';
+  if (raw >= 21000) return 'Revered';
+  if (raw >= 9000) return 'Honored';
+  if (raw >= 3000) return 'Friendly';
+  if (raw >= 0) return 'Neutral';
+  if (raw >= -3000) return 'Unfriendly';
+  if (raw >= -6000) return 'Hostile';
+  return 'Hated';
+}
+
+// Progress within the current tier as a percentage.
+const TIER_MIN: Record<string, number> = {
+  Hated: -42000,
+  Hostile: -6000,
+  Unfriendly: -3000,
+  Neutral: 0,
+  Friendly: 3000,
+  Honored: 9000,
+  Revered: 21000,
+  Exalted: 42000,
+};
+const TIER_MAX: Record<string, number> = {
+  Hated: -6001,
+  Hostile: -3001,
+  Unfriendly: -1,
+  Neutral: 2999,
+  Friendly: 8999,
+  Honored: 20999,
+  Revered: 41999,
+  Exalted: 42999,
+};
+
+function tierPct(standing: string, raw: number): number {
+  if (standing === 'Exalted') return 100;
+  const min = TIER_MIN[standing] ?? 0;
+  const max = TIER_MAX[standing] ?? 0;
+  return Math.min(100, Math.max(0, Math.round(((raw - min) / (max - min + 1)) * 100)));
+}
+
+function valueLabel(standing: string, raw: number): string {
+  if (standing === 'Exalted') return 'Max';
+  const min = TIER_MIN[standing];
+  const max = TIER_MAX[standing];
+  if (min === undefined || max === undefined) return raw.toLocaleString();
+  return `${(raw - min).toLocaleString()} / ${(max - min + 1).toLocaleString()}`;
+}
+
+const BADGE: Record<string, string> = {
+  Exalted: 'bg-amber-500/20 text-amber-300 border-amber-500/40',
+  Revered: 'bg-purple-500/20 text-purple-300 border-purple-500/40',
+  Honored: 'bg-blue-500/20 text-blue-300 border-blue-500/40',
+  Friendly: 'bg-green-500/20 text-green-300 border-green-500/40',
+  Neutral: 'bg-zinc-600/40 text-zinc-400 border-zinc-600/60',
+  Unfriendly: 'bg-orange-700/20 text-orange-400 border-orange-700/40',
+  Hostile: 'bg-red-700/20 text-red-400 border-red-700/40',
+  Hated: 'bg-red-900/30 text-red-500 border-red-900/50',
+};
+
+const BAR: Record<string, string> = {
+  Exalted: 'bg-amber-400',
+  Revered: 'bg-purple-400',
+  Honored: 'bg-blue-400',
+  Friendly: 'bg-green-400',
+  Neutral: 'bg-zinc-400',
+  Unfriendly: 'bg-orange-500',
+  Hostile: 'bg-red-500',
+  Hated: 'bg-red-700',
+};
+
+interface FactionRowProps {
+  rep: ReputationEntry;
+}
+
+function FactionRow({ rep }: FactionRowProps) {
+  const standing = standingFromRaw(rep.standing_value);
+  const pct = tierPct(standing, rep.standing_value);
+  const label = valueLabel(standing, rep.standing_value);
+
+  return (
+    <div className="bg-zinc-800/50 border border-zinc-700/50 rounded px-3 py-2 mb-1">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-sm text-zinc-200">{rep.faction_name}</span>
+        <div className="flex items-center gap-2 ml-4 shrink-0">
+          <span className="text-xs text-zinc-500">{label}</span>
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded border ${BADGE[standing] ?? BADGE['Neutral']}`}
+          >
+            {standing}
+          </span>
+        </div>
+      </div>
+      <div className="w-full bg-zinc-700 rounded-full h-1">
+        <div
+          className={`h-1 rounded-full transition-all ${BAR[standing] ?? BAR['Neutral']}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ExpansionGroupProps {
+  category: string;
+  reputations: ReputationEntry[];
+}
+
+function ExpansionGroup({ category, reputations }: ExpansionGroupProps) {
+  const [open, setOpen] = useState(false);
+  const exaltedCount = reputations.filter(
+    (r) => standingFromRaw(r.standing_value) === 'Exalted'
+  ).length;
+
+  return (
+    <div className="mb-1">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-700/50 hover:bg-zinc-700 px-3 py-2 rounded transition-colors flex items-center justify-between"
+      >
+        <span className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+          {category || 'Other'}
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500">{reputations.length}</span>
+          {exaltedCount > 0 && (
+            <span className="text-xs text-amber-400 font-semibold">{exaltedCount} ✦</span>
+          )}
+          <span className="text-zinc-600 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
+      </button>
+      <CollapsePanel open={open}>
+        <div className="mt-1 pl-2 space-y-0.5">
+          {reputations.map((r) => (
+            <FactionRow key={r.faction} rep={r} />
+          ))}
+        </div>
+      </CollapsePanel>
+    </div>
+  );
+}
+
+interface AltPanelProps {
+  altName: string;
+  reputations: ReputationEntry[];
+}
+
+function AltPanel({ altName, reputations }: AltPanelProps) {
+  const [open, setOpen] = useState(false);
+  const exaltedCount = reputations.filter(
+    (r) => standingFromRaw(r.standing_value) === 'Exalted'
+  ).length;
+
+  const byCategory = useMemo(() => {
+    const EXPANSION_ORDER = [
+      'Midnight',
+      'The War Within',
+      'Dragonflight',
+      'Shadowlands',
+      'Battle for Azeroth',
+      'Legion',
+      'Warlords of Draenor',
+      'Mists of Pandaria',
+      'Cataclysm',
+      'Wrath of the Lich King',
+      'The Burning Crusade',
+      'Classic',
+    ];
+    const map = new Map<string, ReputationEntry[]>();
+    for (const r of reputations) {
+      const cat = r.faction_category || 'Other';
+      const list = map.get(cat) ?? [];
+      list.push(r);
+      map.set(cat, list);
+    }
+    return [...map.entries()].sort(([a], [b]) => {
+      const ai = EXPANSION_ORDER.indexOf(a);
+      const bi = EXPANSION_ORDER.indexOf(b);
+      if (ai === -1 && bi === -1) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  }, [reputations]);
+
+  return (
+    <div className="mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
+      >
+        <span className="text-sm font-medium text-zinc-200">{altName}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-zinc-400">{reputations.length} factions</span>
+          {exaltedCount > 0 && (
+            <span className="text-xs text-amber-400 font-semibold">{exaltedCount} exalted</span>
+          )}
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
+      </button>
+      <CollapsePanel open={open}>
+        <div className="mt-1 pl-1 space-y-1">
+          {byCategory.map(([cat, reps]) => (
+            <ExpansionGroup key={cat} category={cat} reputations={reps} />
+          ))}
+        </div>
+      </CollapsePanel>
+    </div>
+  );
+}
+
+function Reputation() {
+  const [data, setData] = useState<ReputationEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function getData() {
+      try {
+        const res = await axios.get(config.url.API_URL + '/api/profile/altreputations/', {
+          params: { user: cookies.get('userid') },
+        });
+        setData(res.data as ReputationEntry[]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    getData();
+  }, []);
+
+  const byAlt = useMemo(() => {
+    const map = new Map<number, ReputationEntry[]>();
+    for (const r of data) {
+      const list = map.get(r.alt) ?? [];
+      list.push(r);
+      map.set(r.alt, list);
+    }
+    return [...map.values()].sort((a, b) => {
+      const exA = a.filter((r) => standingFromRaw(r.standing_value) === 'Exalted').length;
+      const exB = b.filter((r) => standingFromRaw(r.standing_value) === 'Exalted').length;
+      if (exB !== exA) return exB - exA;
+      return (a[0]?.alt_name ?? '').localeCompare(b[0]?.alt_name ?? '');
+    });
+  }, [data]);
+
+  const totalExalted = useMemo(
+    () =>
+      new Set(
+        data.filter((r) => standingFromRaw(r.standing_value) === 'Exalted').map((r) => r.faction)
+      ).size,
+    [data]
+  );
+
+  return (
+    <PageLayout title={`Reputations — ${totalExalted} exalted factions`}>
+      {loading && <LoadingSpinner />}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {!loading && !error && byAlt.length === 0 && (
+        <p className="text-zinc-500 text-sm">No reputation data found. Run a scan first.</p>
+      )}
+      {!loading && !error && byAlt.length > 0 && (
+        <div className="max-w-2xl">
+          {byAlt.map((reps) => (
+            <AltPanel key={reps[0]?.alt} altName={reps[0]?.alt_name ?? ''} reputations={reps} />
+          ))}
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+
+export default Reputation;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,3 +29,23 @@ export type MaterialItem = [string, number, string, string]; // [name, qty, icon
 export type RecipeData = [string, boolean, number, number, string, ...MaterialItem[]];
 export type CategoryData = [string, RecipeData[]];
 export type TierData = [string, CategoryData[]];
+
+export interface AchievementEntry {
+  alt: number;
+  alt_name: string;
+  achievement: number;
+  achievement_name: string;
+  achievement_points: number;
+  achievement_category: string;
+  completed_timestamp: number | null;
+}
+
+export interface ReputationEntry {
+  alt: number;
+  alt_name: string;
+  faction: number;
+  faction_name: string;
+  faction_category: string;
+  standing_type: string;
+  standing_value: number;
+}


### PR DESCRIPTION
## Summary

- Add `Achievement` page: lazy-loads per category (`?summary=1` on mount, `?category=X` per accordion expand)
- Add `Reputation` page: grouped by alt then expansion, standing derived client-side from raw value, progress bars per faction, alts sorted by exalted count
- Rewrite `MountTable` and `PetTable` as icon grids; uncollected hidden behind toggle; collected/total + % in header
- New types: `AchievementEntry`, `ReputationEntry`
- Routes `/achievement` and `/reputation` added to `App.tsx` and `MenuBar`

## Test plan
- [ ] Visit `/achievement` — should show category summary, then load achievements on expand
- [ ] Visit `/reputation` — should show alts sorted by exalted count with expansion sub-groups
- [ ] Visit `/mount` and `/pet` — icon grid layout, uncollected toggle works
- [ ] Confirm no TS errors (`npm run build`)