### PR TITLE
Make Account alt-centric; add per-alt detail page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ This is a Create React App (React 18) single-page application styled with Tailwi
 ```
 src/
   components/       # Shared UI — imported by multiple pages
-    AltTable.tsx        # Table used by Account, Gear, Profession
+    AccountAltRow.tsx   # Account page's per-alt accordion row (collapsed summary + expand panel)
+    AltTable.tsx        # Table used by Gear, Profession (Account no longer uses this — see below)
     CollapsePanel.tsx   # Animated expand/collapse wrapper
     Header.tsx          # Top bar with brand + Update button
     KeybindUpload.tsx   # .lua addon file upload form (despite the name, generic upload widget)
@@ -30,24 +31,27 @@ src/
     PetTable.tsx        # Pet icon-grid accordion (collected + toggle for uncollected)
     ProfessionTable.tsx # Profession recipe accordion
   pages/            # One file per route
-    Account.tsx
-    Achievement.tsx     # Achievements grouped by category; lazy-loads per-category on expand
+    Account.tsx         # "/" — alt-centric accordion list; click an alt name for AltDetail
+    Achievement.tsx     # Account-wide; grouped by category; lazy-loads per-category on expand
+    AltDetail.tsx       # "/alt/:alt/:realm" — consolidated per-alt view (gear/professions/M+/achievements/reps)
     Auth.tsx
     AuthRedirect.tsx
-    Gear.tsx
-    Home.tsx
+    Gear.tsx            # Account-wide gear overview table
     Logout.tsx
     Mount.tsx
+    MythicPlus.tsx      # Account-wide; accordion per alt sorted by rating
     Pet.tsx
-    Profession.tsx
-    Reputation.tsx      # Reputations grouped by alt → expansion; standing derived from raw value
-    SingleGear.tsx
-    SingleProfession.tsx
+    Profession.tsx      # Account-wide profession overview table
+    Reputation.tsx      # Account-wide; grouped by alt → expansion; standing derived from raw value
+    SingleGear.tsx       # Click-through target from Gear.tsx (NOT from AltDetail, which duplicates this rendering)
+    SingleProfession.tsx # Click-through target from Profession.tsx (same note as SingleGear)
   App.tsx           # BrowserRouter + Routes only
   App.css           # WoW-specific styles (class colors, item quality borders)
+  classColors.ts    # WoW class → hex color map, shared by AltTable and AccountAltRow
   Constants.ts      # API URL config
   cookies.ts        # Shared universal-cookie instance
-  types.ts          # Shared TypeScript types (AltRow, PageType, etc.)
+  format.ts         # capitalize() — shared by SingleGear, SingleProfession, AltDetail
+  types.ts          # Shared TypeScript types (AltRow, PageType, MythicPlusEntry, etc.)
   index.css         # Tailwind directives + body base styles
 ```
 
@@ -74,11 +78,13 @@ Absolute imports are configured via `baseUrl: "src"` in `tsconfig.json`, so impo
 
 `axios.defaults.withCredentials = true` is set globally in `src/index.tsx`.
 
-**Routing** uses React Router v6 (`BrowserRouter` + `Routes`). Detail views use URL params (e.g. `/gear/:alt/:realm`) accessed via `useParams`. The `public/_redirects` file handles Netlify SPA routing so all paths serve `index.html`.
+**Routing** uses React Router v6 (`BrowserRouter` + `Routes`). Detail views use URL params (e.g. `/gear/:alt/:realm`, `/alt/:alt/:realm`) accessed via `useParams`. The `public/_redirects` file handles Netlify SPA routing so all paths serve `index.html`.
 
-**Page layout pattern**: every page uses `<PageLayout title="...">` which renders `<Header />` + sidebar `<MenuBar />` + the page's main content. `MenuBar` conditionally shows authenticated links based on whether the `userid` cookie exists.
+**Page layout pattern**: every page uses `<PageLayout title="...">` which renders `<Header />` + sidebar `<MenuBar />` + the page's main content. `MenuBar` conditionally shows authenticated links based on whether the `userid` cookie exists. `AltDetail` has no sidebar link — it's only reachable by clicking an alt name on the Account page.
 
-**`AltTable`**: shared table used by Account, Gear, and Profession. Per-page rendering is controlled by a `page` prop (`'gear'`, `'profession'`) which governs which columns are hidden and which cells link to detail views.
+**`AltTable`**: shared table used by Gear and Profession (the account-wide overview pages). Per-page rendering is controlled by a `page` prop (`'gear'`, `'profession'`) which governs which columns are hidden and which cells link to detail views. The Account page does **not** use this anymore — it has its own accordion-row component (`AccountAltRow`) since it's expand-in-place rather than tabular.
+
+**Account page redesign (alts as the focal point)**: `Account.tsx` fetches `/api/profile/alts/`, `/api/profile/altmythicplus/`, and `/api/profile/altprofessions/` in parallel and joins them by `alt_id` into a per-alt summary (ilvl, M+ rating, professions) shown inline on expand via `AccountAltRow`. Achievement points and reputation are deliberately *not* shown inline — achievements are scraped from one representative alt per faction (not every alt, see `scan_user_collection` in the backend), so they aren't meaningfully per-alt data; reputation was a judgement call to keep the row light. Clicking an alt's name (not the row background) navigates to `AltDetail` instead of toggling the row. The standalone Gear/Profession/Achievement/Reputation/Mythic+ pages are intentionally untouched by this — they're a known-incomplete first step of a larger planned redesign, not yet decided whether they'll be folded in or stay as account-wide views.
 
 **Data slicing in Mount/Pet**: the API appends count metadata at the end of the response array. `data.slice(0, -3)` passes actual records to the table; `data.slice(-3)` retrieves the counts.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import MythicPlus from 'pages/MythicPlus';
 import Logout from 'pages/Logout';
 import SingleProfession from 'pages/SingleProfession';
 import SingleGear from 'pages/SingleGear';
+import AltDetail from 'pages/AltDetail';
 
 function App() {
   return (
@@ -32,6 +33,7 @@ function App() {
         <Route path="/logout" element={<Logout />} />
         <Route path="/profession/:alt/:realm/:profession" element={<SingleProfession />} />
         <Route path="/gear/:alt/:realm" element={<SingleGear />} />
+        <Route path="/alt/:alt/:realm" element={<AltDetail />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/classColors.ts
+++ b/src/classColors.ts
@@ -1,0 +1,19 @@
+const CLASS_COLORS: Record<string, string> = {
+  Warrior: '#C79C6E',
+  Paladin: '#F58CBA',
+  Hunter: '#ABD473',
+  Rogue: '#FFF569',
+  Priest: '#FFFFFF',
+  Shaman: '#0070DD',
+  Mage: '#69CCF0',
+  Warlock: '#9482C9',
+  Monk: '#00FF96',
+  Druid: '#FF7D0A',
+  DemonHunter: '#A330C9',
+  DeathKnight: '#C41F3B',
+  Evoker: '#33937F',
+};
+
+export function classColor(name: string): string | null {
+  return CLASS_COLORS[name.replace(/\s/g, '')] ?? null;
+}

--- a/src/components/AccountAltRow.tsx
+++ b/src/components/AccountAltRow.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import CollapsePanel from 'components/CollapsePanel';
+import { classColor } from 'classColors';
+
+export interface AccountAlt {
+  altId: number;
+  name: string;
+  realm: string;
+  realmSlug: string;
+  level: number;
+  race: string;
+  className: string;
+  faction: string;
+  ilvl: number;
+}
+
+interface AccountAltRowProps {
+  alt: AccountAlt;
+  mythicRating: number | null;
+  professions: [string, string] | null;
+}
+
+function AccountAltRow({ alt, mythicRating, professions }: AccountAltRowProps) {
+  const [open, setOpen] = useState(false);
+  const color = classColor(alt.className) ?? '#e4e4e7';
+
+  return (
+    <div className="mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-xs text-zinc-500 shrink-0">{alt.level}</span>
+          <Link
+            to={`/alt/${alt.name.toLowerCase()}/${alt.realmSlug}`}
+            onClick={(e) => e.stopPropagation()}
+            style={{ color }}
+            className="text-sm font-medium hover:underline underline-offset-2 truncate"
+          >
+            {alt.name}
+          </Link>
+          <span className="text-xs text-zinc-500 truncate">{alt.realm}</span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <span className="text-xs text-zinc-400">{alt.faction}</span>
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
+      </button>
+      <CollapsePanel open={open}>
+        <div className="mt-1 px-4 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded flex flex-wrap items-center gap-x-6 gap-y-1 text-xs">
+          <span className="text-zinc-400">
+            ilvl <span className="text-zinc-200">{alt.ilvl || '—'}</span>
+          </span>
+          <span className="text-zinc-400">
+            M+ rating{' '}
+            <span className="text-zinc-200">
+              {mythicRating !== null ? mythicRating.toFixed(1) : '—'}
+            </span>
+          </span>
+          <span className="text-zinc-400">
+            Professions{' '}
+            <span className="text-zinc-200">
+              {professions ? professions.filter((p) => p !== 'Missing').join(' / ') || '—' : '—'}
+            </span>
+          </span>
+        </div>
+      </CollapsePanel>
+    </div>
+  );
+}
+
+export default AccountAltRow;

--- a/src/components/AltTable.tsx
+++ b/src/components/AltTable.tsx
@@ -1,29 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { classColor } from 'classColors';
 import type { AltRow, PageType } from 'types';
 
 const tdBase = 'px-4 py-2 border border-zinc-700 text-center text-sm';
 const linkCls = 'text-amber-400 hover:text-amber-300 hover:underline underline-offset-2';
-
-const CLASS_COLORS: Record<string, string> = {
-  Warrior: '#C79C6E',
-  Paladin: '#F58CBA',
-  Hunter: '#ABD473',
-  Rogue: '#FFF569',
-  Priest: '#FFFFFF',
-  Shaman: '#0070DD',
-  Mage: '#69CCF0',
-  Warlock: '#9482C9',
-  Monk: '#00FF96',
-  Druid: '#FF7D0A',
-  DemonHunter: '#A330C9',
-  DeathKnight: '#C41F3B',
-  Evoker: '#33937F',
-};
-
-function classColor(name: string): string | null {
-  return CLASS_COLORS[name.replace(/\s/g, '')] ?? null;
-}
 
 interface AltTableRowDataProps {
   alt: string | number;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,3 @@
+export function capitalize(str: string): string {
+  return str ? str[0].toUpperCase() + str.slice(1) : '';
+}

--- a/src/pages/Account.test.tsx
+++ b/src/pages/Account.test.tsx
@@ -30,8 +30,12 @@ test('shows error message when request fails', async () => {
 });
 
 test('renders alt data on success', async () => {
-  mockedAxios.get.mockResolvedValue({
-    data: [['Alliance', 70, 'Human', 'Warrior', 'Testchar', 'Stormrage', 1]],
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url.includes('/altmythicplus/')) return Promise.resolve({ data: [] });
+    if (url.includes('/altprofessions/')) return Promise.resolve({ data: [] });
+    return Promise.resolve({
+      data: [[1, 'Testchar', 'Stormrage', 'stormrage', 70, 'Human', 'Warrior', 'Alliance', 615]],
+    });
   });
   renderAccount();
   await screen.findByText('Testchar');

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,37 +1,79 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import PageLayout from 'components/PageLayout';
-import AltTable from 'components/AltTable';
 import LoadingSpinner from 'components/LoadingSpinner';
+import AccountAltRow, { type AccountAlt } from 'components/AccountAltRow';
 import { cookies } from 'cookies';
 import { config } from 'Constants';
-import type { AltRow } from 'types';
+import type { MythicPlusEntry } from 'types';
 
-const heads = ['Faction', 'Level', 'Race', 'Class', 'Name', 'Realm', 'Account'];
+type RawAltRow = [number, string, string, string, number, string, string, string, number];
+
+function parseAlt(row: RawAltRow): AccountAlt {
+  return {
+    altId: row[0],
+    name: row[1],
+    realm: row[2],
+    realmSlug: row[3],
+    level: row[4],
+    race: row[5],
+    className: row[6],
+    faction: row[7],
+    ilvl: row[8],
+  };
+}
 
 function Account() {
-  const [data, setData] = useState<AltRow[]>([]);
+  const [alts, setAlts] = useState<AccountAlt[]>([]);
+  const [mythicByAlt, setMythicByAlt] = useState<Map<number, number>>(new Map());
+  const [professionsByAlt, setProfessionsByAlt] = useState<Map<number, [string, string]>>(
+    new Map()
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function getData() {
       try {
-        const response = await axios.get(config.url.API_URL + '/api/profile/alts/', {
-          params: {
-            user: cookies.get('userid'),
-            fields: [
-              'alt_faction',
-              'alt_level',
-              'get_alt_race_display',
-              'get_alt_class_display',
-              'alt_name',
-              'alt_realm',
-              'alt_account_id',
-            ],
-          },
-        });
-        setData(response.data);
+        const user = cookies.get('userid');
+        const [altsRes, mythicRes, professionsRes] = await Promise.all([
+          axios.get(config.url.API_URL + '/api/profile/alts/', {
+            params: {
+              user,
+              fields: [
+                'alt_id',
+                'alt_name',
+                'alt_realm',
+                'alt_realm_slug',
+                'alt_level',
+                'get_alt_race_display',
+                'get_alt_class_display',
+                'alt_faction',
+                'alt_ilvl',
+              ],
+            },
+          }),
+          axios.get(config.url.API_URL + '/api/profile/altmythicplus/', { params: { user } }),
+          axios.get(config.url.API_URL + '/api/profile/altprofessions/', {
+            params: {
+              user,
+              fields: ['.alt_id', 'get_profession_1_display', 'get_profession_2_display'],
+            },
+          }),
+        ]);
+
+        setAlts((altsRes.data as RawAltRow[]).map(parseAlt));
+        setMythicByAlt(
+          new Map((mythicRes.data as MythicPlusEntry[]).map((m) => [m.alt, m.mythic_rating]))
+        );
+        setProfessionsByAlt(
+          new Map(
+            (professionsRes.data as [number, string, string][]).map(([altId, p1, p2]) => [
+              altId,
+              [p1, p2],
+            ])
+          )
+        );
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load data.');
       } finally {
@@ -45,7 +87,18 @@ function Account() {
     <PageLayout title="Account">
       {loading && <LoadingSpinner />}
       {error && <p className="text-red-400 text-sm">{error}</p>}
-      {!loading && !error && <AltTable alts={data} heads={heads} />}
+      {!loading && !error && (
+        <div className="max-w-2xl">
+          {alts.map((alt) => (
+            <AccountAltRow
+              key={alt.altId}
+              alt={alt}
+              mythicRating={mythicByAlt.get(alt.altId) ?? null}
+              professions={professionsByAlt.get(alt.altId) ?? null}
+            />
+          ))}
+        </div>
+      )}
     </PageLayout>
   );
 }

--- a/src/pages/AltDetail.tsx
+++ b/src/pages/AltDetail.tsx
@@ -1,0 +1,287 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import CollapsePanel from 'components/CollapsePanel';
+import PageLayout from 'components/PageLayout';
+import ProfessionTable from 'components/ProfessionTable';
+import LoadingSpinner from 'components/LoadingSpinner';
+import { classColor } from 'classColors';
+import { capitalize } from 'format';
+import { cookies } from 'cookies';
+import { config } from 'Constants';
+import type {
+  AchievementEntry,
+  MythicPlusDungeonEntry,
+  MythicPlusEntry,
+  ReputationEntry,
+  TierData,
+} from 'types';
+
+const GEAR_SLOTS = [
+  'Head',
+  'Neck',
+  'Shoulder',
+  'Back',
+  'Chest',
+  'Tabard',
+  'Shirt',
+  'Wrist',
+  'Hands',
+  'Belt',
+  'Legs',
+  'Feet',
+  'Ring 1',
+  'Ring 2',
+  'Trinket 1',
+  'Trinket 2',
+  'Weapon 1',
+  'Weapon 2',
+];
+
+interface SectionProps {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, subtitle, children }: SectionProps) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="mb-3">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left bg-zinc-800 hover:bg-zinc-700 px-4 py-3 rounded transition-colors flex items-center justify-between"
+      >
+        <span className="text-sm font-semibold text-zinc-200">{title}</span>
+        <div className="flex items-center gap-3">
+          {subtitle && <span className="text-xs text-zinc-400">{subtitle}</span>}
+          <span className="text-zinc-500 text-xs">{open ? '▲' : '▼'}</span>
+        </div>
+      </button>
+      <CollapsePanel open={open}>
+        <div className="mt-2 pl-1">{children}</div>
+      </CollapsePanel>
+    </div>
+  );
+}
+
+interface ClassHeader {
+  altName: string;
+  realmSlug: string;
+  className: string;
+  profession1: string;
+  profession2: string;
+}
+
+function AltDetail() {
+  const { alt, realm } = useParams<{ alt: string; realm: string }>();
+  const [header, setHeader] = useState<ClassHeader | null>(null);
+  const [gear, setGear] = useState<[string, number][]>([]);
+  const [prof1Data, setProf1Data] = useState<TierData[]>([]);
+  const [prof2Data, setProf2Data] = useState<TierData[]>([]);
+  const [mythicSummary, setMythicSummary] = useState<MythicPlusEntry | null>(null);
+  const [mythicDungeons, setMythicDungeons] = useState<MythicPlusDungeonEntry[]>([]);
+  const [achievements, setAchievements] = useState<AchievementEntry[]>([]);
+  const [reputations, setReputations] = useState<ReputationEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!alt || !realm) return;
+    const altName = alt;
+    const realmSlug = realm;
+    async function getData() {
+      try {
+        const user = cookies.get('userid');
+
+        const professionsRes = await axios.get(
+          config.url.API_URL + '/api/profile/altprofessions/',
+          {
+            params: {
+              user,
+              fields: [
+                '.alt_name',
+                '.alt_realm_slug',
+                '.get_alt_class_display',
+                'get_profession_1_display',
+                'get_profession_2_display',
+              ],
+            },
+          }
+        );
+        const rows = professionsRes.data as [string, string, string, string, string][];
+        const match = rows.find(
+          ([name, slug]) => name.toLowerCase() === altName.toLowerCase() && slug === realmSlug
+        );
+        const prof1Name = match?.[3] ?? 'Missing';
+        const prof2Name = match?.[4] ?? 'Missing';
+        setHeader({
+          altName: match?.[0] ?? capitalize(altName),
+          realmSlug: realmSlug,
+          className: match?.[2] ?? '',
+          profession1: prof1Name,
+          profession2: prof2Name,
+        });
+
+        const params = { user, alt: altName, realm: realmSlug };
+        const [gearRes, prof1Res, prof2Res, mythicRes, dungeonsRes, achievementsRes, repsRes] =
+          await Promise.all([
+            axios.get(config.url.API_URL + '/api/profile/altequipments/', {
+              params: { page: 'single', alt: altName, realm: realmSlug },
+            }),
+            prof1Name === 'Missing'
+              ? Promise.resolve({ data: [] })
+              : axios.get(config.url.API_URL + '/api/profile/altprofessiondatas/', {
+                  params: { alt: altName, realm: realmSlug, profession: prof1Name },
+                }),
+            prof2Name === 'Missing'
+              ? Promise.resolve({ data: [] })
+              : axios.get(config.url.API_URL + '/api/profile/altprofessiondatas/', {
+                  params: { alt: altName, realm: realmSlug, profession: prof2Name },
+                }),
+            axios.get(config.url.API_URL + '/api/profile/altmythicplus/', { params }),
+            axios.get(config.url.API_URL + '/api/profile/altmythicplusdungeons/', { params }),
+            axios.get(config.url.API_URL + '/api/profile/altachievements/', { params }),
+            axios.get(config.url.API_URL + '/api/profile/altreputations/', { params }),
+          ]);
+
+        setGear(gearRes.data as [string, number][]);
+        setProf1Data(prof1Res.data as TierData[]);
+        setProf2Data(prof2Res.data as TierData[]);
+        setMythicSummary((mythicRes.data as MythicPlusEntry[])[0] ?? null);
+        setMythicDungeons(dungeonsRes.data as MythicPlusDungeonEntry[]);
+        setAchievements(achievementsRes.data as AchievementEntry[]);
+        setReputations(repsRes.data as ReputationEntry[]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    getData();
+  }, [alt, realm]);
+
+  if (!alt || !realm) return null;
+
+  const color = header ? (classColor(header.className) ?? '#e4e4e7') : '#e4e4e7';
+  const title = header ? `${header.altName} — ${capitalize(realm)}` : capitalize(alt);
+  const achievementPoints = achievements.reduce((s, a) => s + a.achievement_points, 0);
+
+  return (
+    <PageLayout title={title}>
+      {loading && <LoadingSpinner />}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {!loading && !error && header && (
+        <div className="max-w-3xl">
+          <p className="text-sm mb-4" style={{ color }}>
+            {header.className}
+          </p>
+
+          <Section title="Gear">
+            <table className="border-collapse text-sm w-full max-w-md">
+              <tbody>
+                {gear.map((item, index) => (
+                  <tr key={index} className="hover:bg-zinc-800/50 transition-colors">
+                    <td className="bg-zinc-900 px-4 py-2 border border-zinc-700 text-zinc-400 text-sm">
+                      {GEAR_SLOTS[index]}
+                    </td>
+                    <td className="bg-zinc-900 px-4 py-2 border border-zinc-700 text-zinc-200 text-sm">
+                      {item[0]}
+                    </td>
+                    <td className="bg-zinc-900 px-4 py-2 border border-zinc-700 text-zinc-200 text-sm text-center">
+                      {item[1]}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+
+          {header.profession1 !== 'Missing' && (
+            <Section title={header.profession1}>
+              <ProfessionTable tiers={prof1Data} />
+            </Section>
+          )}
+          {header.profession2 !== 'Missing' && (
+            <Section title={header.profession2}>
+              <ProfessionTable tiers={prof2Data} />
+            </Section>
+          )}
+
+          <Section
+            title="Mythic+"
+            subtitle={mythicSummary ? `${mythicSummary.mythic_rating.toFixed(1)} rating` : '—'}
+          >
+            {mythicDungeons.length === 0 ? (
+              <p className="text-zinc-500 text-xs px-2 py-1">No dungeon runs recorded.</p>
+            ) : (
+              [...mythicDungeons]
+                .sort((a, b) => b.score - a.score)
+                .map((d) => (
+                  <div
+                    key={d.dungeon}
+                    className="bg-zinc-800/50 border border-zinc-700/50 rounded px-3 py-2 mb-1 flex items-center justify-between"
+                  >
+                    <span className="text-sm text-zinc-200">{d.dungeon_name}</span>
+                    <div className="flex items-center gap-2 ml-4 shrink-0">
+                      <span className="text-xs text-zinc-500">{d.score.toFixed(1)}</span>
+                      <span
+                        className={`text-xs font-medium px-2 py-0.5 rounded border ${
+                          d.is_completed_within_time
+                            ? 'bg-green-500/20 text-green-300 border-green-500/40'
+                            : 'bg-zinc-600/40 text-zinc-400 border-zinc-600/60'
+                        }`}
+                      >
+                        +{d.keystone_level}
+                      </span>
+                    </div>
+                  </div>
+                ))
+            )}
+          </Section>
+
+          <Section title="Achievements" subtitle={`${achievementPoints.toLocaleString()} pts`}>
+            {achievements.length === 0 ? (
+              <p className="text-zinc-500 text-xs px-2 py-1">No achievements recorded.</p>
+            ) : (
+              achievements.map((a) => (
+                <div
+                  key={a.achievement}
+                  className="flex items-center justify-between bg-zinc-800/50 border border-zinc-700/50 rounded px-3 py-2 mb-1"
+                >
+                  <span className="text-sm text-zinc-200">{a.achievement_name}</span>
+                  <span className="text-xs text-amber-400/80 font-medium ml-4 shrink-0">
+                    {a.achievement_points} pts
+                  </span>
+                </div>
+              ))
+            )}
+          </Section>
+
+          <Section title="Reputations">
+            {reputations.length === 0 ? (
+              <p className="text-zinc-500 text-xs px-2 py-1">No reputation data recorded.</p>
+            ) : (
+              [...reputations]
+                .sort((a, b) => b.standing_value - a.standing_value)
+                .map((r) => (
+                  <div
+                    key={r.faction}
+                    className="flex items-center justify-between bg-zinc-800/50 border border-zinc-700/50 rounded px-3 py-2 mb-1"
+                  >
+                    <span className="text-sm text-zinc-200">{r.faction_name}</span>
+                    <span className="text-xs text-zinc-400 ml-4 shrink-0">
+                      {r.standing_value.toLocaleString()}
+                    </span>
+                  </div>
+                ))
+            )}
+          </Section>
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+
+export default AltDetail;

--- a/src/pages/SingleGear.tsx
+++ b/src/pages/SingleGear.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import PageLayout from 'components/PageLayout';
 import LoadingSpinner from 'components/LoadingSpinner';
 import { config } from 'Constants';
+import { capitalize } from 'format';
 
 const slots = [
   'Head',
@@ -23,10 +24,6 @@ const slots = [
   'Weapon 1',
   'Weapon 2',
 ];
-
-function capitalize(str: string): string {
-  return str ? str[0].toUpperCase() + str.slice(1) : '';
-}
 
 function SingleGear() {
   const [data, setData] = useState<[string, number][]>([]);

--- a/src/pages/SingleProfession.tsx
+++ b/src/pages/SingleProfession.tsx
@@ -5,11 +5,8 @@ import PageLayout from 'components/PageLayout';
 import ProfessionTable from 'components/ProfessionTable';
 import LoadingSpinner from 'components/LoadingSpinner';
 import { config } from 'Constants';
+import { capitalize } from 'format';
 import type { TierData } from 'types';
-
-function capitalize(str: string): string {
-  return str ? str[0].toUpperCase() + str.slice(1) : '';
-}
 
 function SingleProfession() {
   const [data, setData] = useState<TierData[]>([]);


### PR DESCRIPTION
## Summary
- `Account.tsx` reworked from the shared `AltTable` into an accordion list, joining `alts`/`altmythicplus`/`altprofessions` by `alt_id`. Each row shows the collapsed summary it always did, plus an inline expand panel with ilvl, M+ rating, and professions. Achievement points and reputation are deliberately left out of the inline row — achievements come from one representative alt per faction (`scan_user_collection`), not every alt, so they aren't meaningfully per-alt data.
- Clicking an alt's name opens a new `AltDetail` page (`/alt/:alt/:realm`), consolidating gear, both professions, M+ rating/dungeons, achievements, and reputations for that one alt into collapsible sections — fetched in parallel from existing per-alt endpoints, no backend changes.
- The standalone Gear/Profession/Achievement/Reputation/Mythic+ pages, and `SingleGear`/`SingleProfession` (still used by Gear/Profession's click-throughs), are untouched. This is step one of a larger planned redesign, not a replacement.
- Extracted `classColors.ts` and `format.ts` (`capitalize`) since both were about to be duplicated a third time.
- Also caught CLAUDE.md up — it still listed the deleted `Home.tsx` and was missing the Mythic+ page from the prior session.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm test -- --watchAll=false` — 12 passed (updated `Account.test.tsx`'s success-case mock for the new multi-endpoint fetch shape)
- [x] `npm run build` — compiles successfully
- [x] `npm run lint` (oxlint) / `npm run format:check` (prettier) — clean
- [ ] No browser verification — the user verifies UI changes themselves, per established workflow for this project
