### PR TITLE
Replace sidebar nav with a single top nav bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ src/
     AccountTable.tsx    # Account page's per-alt table (ilvl, M+ rating, professions as columns)
     AltTable.tsx        # Table used by Gear, Profession (Account no longer uses this — see below)
     CollapsePanel.tsx   # Animated expand/collapse wrapper
-    Header.tsx          # Top bar with brand + Update button
+    Header.tsx          # Top nav bar: brand + MenuBar nav links + Update button + staleness banner
     KeybindUpload.tsx   # .lua addon file upload form (despite the name, generic upload widget)
-    MenuBar.tsx         # Sidebar nav (includes SidebarLink, LoginLogout)
+    MenuBar.tsx         # Inline top nav links (includes NavLink, LoginLogout); active tab underlined
     MountTable.tsx      # Mount icon-grid accordion (collected + toggle for uncollected)
-    PageLayout.tsx      # Wraps Header + MenuBar sidebar + main content
+    PageLayout.tsx      # Wraps Header (top nav) + a centered max-w-7xl main content area
     PetTable.tsx        # Pet icon-grid accordion (collected + toggle for uncollected)
     ProfessionTable.tsx # Profession recipe accordion
   pages/            # One file per route
@@ -80,7 +80,7 @@ Absolute imports are configured via `baseUrl: "src"` in `tsconfig.json`, so impo
 
 **Routing** uses React Router v6 (`BrowserRouter` + `Routes`). Detail views use URL params (e.g. `/gear/:alt/:realm`, `/alt/:alt/:realm`) accessed via `useParams`. The `public/_redirects` file handles Netlify SPA routing so all paths serve `index.html`.
 
-**Page layout pattern**: every page uses `<PageLayout title="...">` which renders `<Header />` + sidebar `<MenuBar />` + the page's main content. `MenuBar` conditionally shows authenticated links based on whether the `userid` cookie exists. `AltDetail` has no sidebar link — it's only reachable by clicking an alt name on the Account page.
+**Page layout pattern**: every page uses `<PageLayout title="...">` which renders `<Header />` (a single top nav bar — brand, `<MenuBar />` nav links, and Update controls all in one row, modelled on a sibling project's `renegades-bot/web/templates/base.html`) + a centered `max-w-7xl` main content area. `MenuBar` conditionally shows authenticated links based on whether the `userid` cookie exists, and underlines the active tab via `useLocation()`. `AltDetail` has no nav link — it's only reachable by clicking an alt name on the Account page.
 
 **`AltTable`**: shared table used by Gear and Profession (the account-wide overview pages). Per-page rendering is controlled by a `page` prop (`'gear'`, `'profession'`) which governs which columns are hidden and which cells link to detail views. The Account page does **not** use this anymore — it has its own table component (`AccountTable`), styled separately since it needs extra columns (ilvl, M+ rating, professions) that `AltTable`'s `page` prop branching doesn't support.
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
+import MenuBar from 'components/MenuBar';
 import { cookies } from 'cookies';
 import { config } from 'Constants';
 
@@ -69,11 +71,16 @@ function Header() {
         ? 'bg-green-700 text-zinc-100'
         : 'bg-amber-600 hover:bg-amber-500 text-zinc-950';
 
-  if (cookies.get('userid')) {
-    return (
-      <>
-        <header className="bg-zinc-900 border-b border-zinc-800 px-6 py-4 flex items-center justify-between shrink-0">
-          <h1 className="text-2xl font-bold text-amber-400 tracking-wide">Fazz Tools</h1>
+  return (
+    <>
+      <header className="bg-zinc-900 border-b border-zinc-800 px-6 py-3 flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-6">
+          <Link to="/" className="text-lg font-bold text-amber-400 tracking-wide">
+            Fazz Tools
+          </Link>
+          <MenuBar />
+        </div>
+        {cookies.get('userid') && (
           <div className="flex items-center gap-4">
             <span className="text-zinc-400 text-sm">Last updated: {update}</span>
             <button
@@ -84,20 +91,14 @@ function Header() {
               {btnLabel}
             </button>
           </div>
-        </header>
-        {stale && (
-          <div className="bg-amber-900/60 border-b border-amber-700 px-6 py-2 text-amber-300 text-sm text-center">
-            Your data is over 30 days old — click <strong>Update</strong> to sync your characters.
-          </div>
         )}
-      </>
-    );
-  }
-
-  return (
-    <header className="bg-zinc-900 border-b border-zinc-800 px-6 py-4">
-      <h1 className="text-2xl font-bold text-amber-400 tracking-wide">Fazz Tools</h1>
-    </header>
+      </header>
+      {cookies.get('userid') && stale && (
+        <div className="bg-amber-900/60 border-b border-amber-700 px-6 py-2 text-amber-300 text-sm text-center">
+          Your data is over 30 days old — click <strong>Update</strong> to sync your characters.
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { cookies } from 'cookies';
 
-interface SidebarLinkProps {
+interface NavLinkProps {
   to: string;
   danger?: boolean;
   children: React.ReactNode;
 }
 
-function SidebarLink({ to, children, danger }: SidebarLinkProps) {
-  const base = 'block py-2 px-3 rounded text-sm transition-colors';
+function NavLink({ to, children, danger }: NavLinkProps) {
+  const { pathname } = useLocation();
+  const active = to === '/' ? pathname === '/' : pathname.startsWith(to);
   const colour = danger
-    ? 'text-red-400 hover:bg-zinc-800 hover:text-red-300'
-    : 'text-zinc-300 hover:bg-zinc-800 hover:text-amber-400';
+    ? 'text-red-400 hover:text-red-300'
+    : active
+      ? 'text-zinc-100 border-b border-amber-400 pb-0.5'
+      : 'text-zinc-400 hover:text-zinc-100';
   return (
-    <Link to={to} className={`${base} ${colour}`}>
+    <Link to={to} className={`text-sm ${colour}`}>
       {children}
     </Link>
   );
@@ -24,28 +27,26 @@ function LoginLogout() {
   if (cookies.get('userid')) {
     return (
       <>
-        <SidebarLink to="/">Account</SidebarLink>
-        <SidebarLink to="/gear">Gear</SidebarLink>
-        <SidebarLink to="/profession">Profession</SidebarLink>
-        <SidebarLink to="/mount">Mount</SidebarLink>
-        <SidebarLink to="/pet">Pet</SidebarLink>
-        <SidebarLink to="/achievement">Achievements</SidebarLink>
-        <SidebarLink to="/reputation">Reputations</SidebarLink>
-        <SidebarLink to="/mythicplus">Mythic+</SidebarLink>
-        <div className="mt-4 pt-4 border-t border-zinc-800">
-          <SidebarLink to="/logout" danger>
-            Logout
-          </SidebarLink>
-        </div>
+        <NavLink to="/">Account</NavLink>
+        <NavLink to="/gear">Gear</NavLink>
+        <NavLink to="/profession">Profession</NavLink>
+        <NavLink to="/mount">Mount</NavLink>
+        <NavLink to="/pet">Pet</NavLink>
+        <NavLink to="/achievement">Achievements</NavLink>
+        <NavLink to="/reputation">Reputations</NavLink>
+        <NavLink to="/mythicplus">Mythic+</NavLink>
+        <NavLink to="/logout" danger>
+          Logout
+        </NavLink>
       </>
     );
   }
-  return <SidebarLink to="/auth">Login</SidebarLink>;
+  return <NavLink to="/auth">Login</NavLink>;
 }
 
 function MenuBar() {
   return (
-    <nav className="p-3 space-y-1">
+    <nav className="flex items-center gap-5">
       <LoginLogout />
     </nav>
   );

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Header from 'components/Header';
-import MenuBar from 'components/MenuBar';
 import ErrorBoundary from 'components/ErrorBoundary';
 
 interface PageLayoutProps {
@@ -12,15 +11,10 @@ function PageLayout({ title, children }: PageLayoutProps) {
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100 flex flex-col">
       <Header />
-      <div className="flex flex-1">
-        <aside className="w-44 bg-zinc-900 border-r border-zinc-800 sticky top-0 h-screen overflow-y-auto shrink-0">
-          <MenuBar />
-        </aside>
-        <main className="flex-1 p-6 overflow-x-auto min-w-0">
-          {title && <h2 className="text-xl font-semibold text-zinc-100 mb-5">{title}</h2>}
-          <ErrorBoundary>{children}</ErrorBoundary>
-        </main>
-      </div>
+      <main className="flex-1 p-6 max-w-7xl mx-auto w-full overflow-x-auto">
+        {title && <h2 className="text-xl font-semibold text-zinc-100 mb-5">{title}</h2>}
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Modelled on a sibling project's (renegades-bot) `base.html`: a single top nav bar with brand and page links inline (active tab underlined via `useLocation`), Update controls on the right — replacing the old Header bar + separate left sidebar.
- `MenuBar` drops its vertical `SidebarLink` styling for an inline `NavLink`.
- `Header` folds `MenuBar` in directly instead of `PageLayout` rendering it in a separate `<aside>`.
- Main content is now a centered `max-w-7xl` container instead of being sidebar-relative.
- Color tokens (zinc/amber) are unchanged — already close enough to renegades-bot's gray/yellow that a token rename wasn't worth it.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `npm test -- --watchAll=false` — 12 passed
- [x] `npm run build` — compiles successfully
- [x] `npm run lint` (oxlint) / `npm run format:check` (prettier) — clean
- [x] Grepped the dev-server bundle for the new layout classes (`max-w-7xl`, `border-amber-400`) and confirmed the old sidebar width class is gone from source
- [ ] No full visual verification — the user verifies UI changes themselves
