### PR TITLE
Surface addon gold/played time and auto-refresh alt data hourly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,11 @@ This is a Create React App (React 18) single-page application styled with Tailwi
 ```
 src/
   components/       # Shared UI — imported by multiple pages
-    AccountTable.tsx    # Account page's per-alt table (ilvl, M+ rating, professions as columns)
+    AccountTable.tsx    # Account page's per-alt table (ilvl, M+ rating, professions, gold, played time as columns)
+    AddonFileUpload.tsx # .lua addon file upload form, mounted on Account above AccountTable
     AltTable.tsx        # Table used by Gear only (Account no longer uses this — see below)
     CollapsePanel.tsx   # Animated expand/collapse wrapper
     Header.tsx          # Top nav bar: brand + MenuBar nav links + Update button + staleness banner
-    KeybindUpload.tsx   # .lua addon file upload form (despite the name, generic upload widget)
     MenuBar.tsx         # Inline top nav links (includes NavLink, LoginLogout); active tab underlined
     MountTable.tsx      # Mount icon-grid accordion (collected + toggle for uncollected)
     PageLayout.tsx      # Wraps Header (top nav) + a centered max-w-7xl main content area
@@ -87,7 +87,7 @@ Absolute imports are configured via `baseUrl: "src"` in `tsconfig.json`, so impo
 
 **Data slicing in Mount/Pet**: the API appends count metadata at the end of the response array. `data.slice(0, -3)` passes actual records to the table; `data.slice(-3)` retrieves the counts.
 
-**Addon file upload**: users upload a `.lua` file (WoW addon export) via `KeybindUpload`, which PUTs it to the backend as `multipart/form-data`. The backend currently only stores it (no feature consumes it yet — reserved for future addon-only data like gold/currencies/lockouts).
+**Addon file upload**: users upload a `.lua` file (WoW addon export) via `AddonFileUpload`, mounted above `AccountTable` on the Account page, which PUTs it to the backend as `multipart/form-data`. `Account.tsx` joins the parsed gold/played-time data (`/api/profile/users/?page=addon`) into `AccountTable`'s Gold and Played Time columns — `'—'` when an alt hasn't appeared in an uploaded file yet. Currencies/lockouts/keystone/vault are captured by the addon but not yet surfaced (same join pattern, not built).
 
 ### Styling
 

--- a/src/components/AccountTable.tsx
+++ b/src/components/AccountTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { classColor } from 'classColors';
+import { formatGold, formatPlayedTime } from 'format';
 
 export interface AccountAlt {
   altId: number;
@@ -12,6 +13,11 @@ export interface AccountAlt {
   className: string;
   faction: string;
   ilvl: number;
+}
+
+export interface AddonAltData {
+  gold: number | null;
+  playedTimeTotal: number | null;
 }
 
 const thBase =
@@ -45,6 +51,7 @@ interface AccountTableRowProps {
   alt: AccountAlt;
   mythicRating: number | null;
   professions: [string, string] | null;
+  addon: AddonAltData | null;
   rowNumber: number;
   index: number;
 }
@@ -53,6 +60,7 @@ function AccountTableRow({
   alt,
   mythicRating,
   professions,
+  addon,
   rowNumber,
   index,
 }: AccountTableRowProps) {
@@ -82,6 +90,12 @@ function AccountTableRow({
       </td>
       <ProfessionCell altName={alt.name} realmSlug={alt.realmSlug} profession={prof1} />
       <ProfessionCell altName={alt.name} realmSlug={alt.realmSlug} profession={prof2} />
+      <td className={`${tdBase} text-zinc-300 text-right`}>
+        {addon?.gold != null ? formatGold(addon.gold) : '—'}
+      </td>
+      <td className={`${tdBase} text-zinc-300 text-center`}>
+        {addon?.playedTimeTotal != null ? formatPlayedTime(addon.playedTimeTotal) : '—'}
+      </td>
     </tr>
   );
 }
@@ -90,9 +104,10 @@ interface AccountTableProps {
   alts: AccountAlt[];
   mythicByAlt: Map<number, number>;
   professionsByAlt: Map<number, [string, string]>;
+  addonByAlt: Map<number, AddonAltData>;
 }
 
-function AccountTable({ alts, mythicByAlt, professionsByAlt }: AccountTableProps) {
+function AccountTable({ alts, mythicByAlt, professionsByAlt, addonByAlt }: AccountTableProps) {
   return (
     <div className="overflow-x-auto rounded border border-zinc-800">
       <table className="border-collapse text-sm w-full">
@@ -108,6 +123,8 @@ function AccountTable({ alts, mythicByAlt, professionsByAlt }: AccountTableProps
             <th className={thBase}>M+ Rating</th>
             <th className={thBase}>Profession 1</th>
             <th className={thBase}>Profession 2</th>
+            <th className={`${thBase} text-right`}>Gold</th>
+            <th className={thBase}>Played Time</th>
           </tr>
         </thead>
         <tbody>
@@ -117,6 +134,7 @@ function AccountTable({ alts, mythicByAlt, professionsByAlt }: AccountTableProps
               alt={alt}
               mythicRating={mythicByAlt.get(alt.altId) ?? null}
               professions={professionsByAlt.get(alt.altId) ?? null}
+              addon={addonByAlt.get(alt.altId) ?? null}
               rowNumber={index + 1}
               index={index}
             />

--- a/src/components/AddonFileUpload.test.tsx
+++ b/src/components/AddonFileUpload.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import KeybindUpload from './KeybindUpload';
+import AddonFileUpload from './AddonFileUpload';
 
 jest.mock('axios');
 jest.mock('cookies', () => ({ cookies: { get: jest.fn(() => 'user123'), set: jest.fn() } }));
@@ -12,12 +12,12 @@ function luaFile(name = 'binds.lua', sizeBytes = 1024) {
 }
 
 test('submit is disabled with no file selected', () => {
-  render(<KeybindUpload inputKey={1} onChange={() => {}} />);
+  render(<AddonFileUpload inputKey={1} onChange={() => {}} />);
   expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
 });
 
 test('shows error and keeps submit disabled for non-.lua file', () => {
-  render(<KeybindUpload inputKey={1} onChange={() => {}} />);
+  render(<AddonFileUpload inputKey={1} onChange={() => {}} />);
   const input = document.querySelector('input[type="file"]') as HTMLInputElement;
 
   const txtFile = new File(['content'], 'export.txt', { type: 'text/plain' });
@@ -28,7 +28,7 @@ test('shows error and keeps submit disabled for non-.lua file', () => {
 });
 
 test('shows error and keeps submit disabled for oversized .lua file', () => {
-  render(<KeybindUpload inputKey={1} onChange={() => {}} />);
+  render(<AddonFileUpload inputKey={1} onChange={() => {}} />);
   const input = document.querySelector('input[type="file"]') as HTMLInputElement;
 
   const bigFile = luaFile('big.lua', 6 * 1024 * 1024);
@@ -39,7 +39,7 @@ test('shows error and keeps submit disabled for oversized .lua file', () => {
 });
 
 test('enables submit and clears errors for a valid .lua file', async () => {
-  render(<KeybindUpload inputKey={1} onChange={() => {}} />);
+  render(<AddonFileUpload inputKey={1} onChange={() => {}} />);
   const input = document.querySelector('input[type="file"]') as HTMLInputElement;
 
   await userEvent.upload(input, luaFile('FazzToolsScraperDB.lua', 50 * 1024));

--- a/src/components/AddonFileUpload.tsx
+++ b/src/components/AddonFileUpload.tsx
@@ -14,12 +14,12 @@ function validateFile(file: File | null): string | null {
   return null;
 }
 
-interface KeybindUploadProps {
+interface AddonFileUploadProps {
   inputKey: React.Key;
   onChange: (timestamp: number) => void;
 }
 
-function KeybindUpload({ inputKey, onChange }: KeybindUploadProps) {
+function AddonFileUpload({ inputKey, onChange }: AddonFileUploadProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [uploadState, setUploadState] = useState<UploadState>('idle');
@@ -100,4 +100,4 @@ function KeybindUpload({ inputKey, onChange }: KeybindUploadProps) {
   );
 }
 
-export default KeybindUpload;
+export default AddonFileUpload;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import MenuBar from 'components/MenuBar';
 import { cookies } from 'cookies';
 import { config } from 'Constants';
 
-const COOLDOWN_MS = 300_000;
 const STALE_MS = 30 * 24 * 60 * 60 * 1000;
-
-type BtnState = 'idle' | 'loading' | 'done' | 'error';
+const AUTO_SCAN_INTERVAL_MS = 3_600_000;
 
 function isStale(lastupdate: string | undefined): boolean {
   if (!lastupdate) return false;
@@ -16,60 +14,35 @@ function isStale(lastupdate: string | undefined): boolean {
 }
 
 function Header() {
-  const [update, setUpdate] = useState(
-    new Date(parseInt(cookies.get('lastupdate'))).toLocaleString()
+  const initialLastUpdate = cookies.get('lastupdate');
+  const [update, setUpdate] = useState<string | null>(
+    initialLastUpdate ? new Date(parseInt(initialLastUpdate)).toLocaleString() : null
   );
-  const [btnState, setBtnState] = useState<BtnState>('idle');
 
-  async function updateAllAlt() {
-    setBtnState('loading');
-    try {
-      await axios.post(config.url.API_URL + '/api/custom/scanalt/', {
-        userid: cookies.get('userid'),
-      });
-      cookies.set('lastupdate', new Date().getTime(), {
-        path: '/',
-        sameSite: 'lax',
-        secure: true,
-      });
-      setUpdate(new Date(parseInt(cookies.get('lastupdate'))).toLocaleString());
-      setBtnState('done');
-    } catch {
-      setBtnState('error');
-    } finally {
-      setTimeout(() => setBtnState('idle'), 3000);
+  useEffect(() => {
+    if (!cookies.get('userid')) return;
+
+    const lastupdate: string | undefined = cookies.get('lastupdate');
+    const needsScan = !lastupdate || Date.now() - parseInt(lastupdate) > AUTO_SCAN_INTERVAL_MS;
+    if (!needsScan) return;
+
+    async function autoScan() {
+      try {
+        await axios.post(config.url.API_URL + '/api/custom/scanalt/', {
+          userid: cookies.get('userid'),
+        });
+        const now = Date.now();
+        cookies.set('lastupdate', now, { path: '/', sameSite: 'lax', secure: true });
+        setUpdate(new Date(now).toLocaleString());
+      } catch (err) {
+        console.error('Auto-scan failed:', err);
+      }
     }
-  }
-
-  async function getLastUpdate() {
-    const response = await axios.get(config.url.API_URL + '/api/profile/users/', {
-      params: { user: cookies.get('userid'), page: 'header' },
-    });
-    cookies.set('lastupdate', response.data[0], { path: '/', sameSite: 'lax', secure: true });
-    setUpdate(new Date(response.data[0]).toLocaleString());
-  }
-
-  if (cookies.get('userid') && !cookies.get('lastupdate')) {
-    void getLastUpdate();
-  }
+    void autoScan();
+  }, []);
 
   const lastupdate: string | undefined = cookies.get('lastupdate');
-  const onCooldown = btnState !== 'idle' || Date.now() < parseInt(lastupdate ?? '0') + COOLDOWN_MS;
   const stale = isStale(lastupdate);
-
-  const btnLabels: Record<BtnState, string> = {
-    idle: 'Update',
-    loading: 'Updating…',
-    done: 'Queued!',
-    error: 'Failed',
-  };
-  const btnLabel = btnLabels[btnState];
-  const btnCls =
-    btnState === 'error'
-      ? 'bg-red-700 hover:bg-red-600 text-zinc-100'
-      : btnState === 'done'
-        ? 'bg-green-700 text-zinc-100'
-        : 'bg-amber-600 hover:bg-amber-500 text-zinc-950';
 
   return (
     <>
@@ -81,21 +54,12 @@ function Header() {
           <MenuBar />
         </div>
         {cookies.get('userid') && (
-          <div className="flex items-center gap-4">
-            <span className="text-zinc-400 text-sm">Last updated: {update}</span>
-            <button
-              disabled={onCooldown}
-              onClick={updateAllAlt}
-              className={`${btnCls} disabled:opacity-40 disabled:cursor-not-allowed font-semibold px-3 py-1.5 rounded text-sm transition-colors`}
-            >
-              {btnLabel}
-            </button>
-          </div>
+          <span className="text-zinc-400 text-sm">Last updated: {update ?? 'pending…'}</span>
         )}
       </header>
       {cookies.get('userid') && stale && (
         <div className="bg-amber-900/60 border-b border-amber-700 px-6 py-2 text-amber-300 text-sm text-center">
-          Your data is over 30 days old — click <strong>Update</strong> to sync your characters.
+          Your data is over 30 days old — it will refresh automatically the next time you visit.
         </div>
       )}
     </>

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,3 +1,13 @@
 export function capitalize(str: string): string {
   return str ? str[0].toUpperCase() + str.slice(1) : '';
 }
+
+export function formatGold(copper: number): string {
+  return `${Math.floor(copper / 10000).toLocaleString()}g`;
+}
+
+export function formatPlayedTime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  return `${days}d ${hours}h`;
+}

--- a/src/pages/Account.test.tsx
+++ b/src/pages/Account.test.tsx
@@ -33,6 +33,7 @@ test('renders alt data on success', async () => {
   mockedAxios.get.mockImplementation((url: string) => {
     if (url.includes('/altmythicplus/')) return Promise.resolve({ data: [] });
     if (url.includes('/altprofessions/')) return Promise.resolve({ data: [] });
+    if (url.includes('/api/profile/users/')) return Promise.resolve({ data: [] });
     return Promise.resolve({
       data: [[1, 'Testchar', 'Stormrage', 'stormrage', 70, 'Human', 'Warrior', 'Alliance', 615]],
     });

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,13 +1,21 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import PageLayout from 'components/PageLayout';
 import LoadingSpinner from 'components/LoadingSpinner';
-import AccountTable, { type AccountAlt } from 'components/AccountTable';
+import AddonFileUpload from 'components/AddonFileUpload';
+import AccountTable, { type AccountAlt, type AddonAltData } from 'components/AccountTable';
 import { cookies } from 'cookies';
 import { config } from 'Constants';
 import type { MythicPlusEntry } from 'types';
 
 type RawAltRow = [number, string, string, string, number, string, string, string, number];
+
+interface RawAddonAltData {
+  alt_id: number;
+  gold: number | null;
+  played_time_total: number | null;
+  played_time_level: number | null;
+}
 
 function parseAlt(row: RawAltRow): AccountAlt {
   return {
@@ -29,69 +37,95 @@ function Account() {
   const [professionsByAlt, setProfessionsByAlt] = useState<Map<number, [string, string]>>(
     new Map()
   );
+  const [addonByAlt, setAddonByAlt] = useState<Map<number, AddonAltData>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [uploadKey, setUploadKey] = useState(0);
+
+  const getData = useCallback(async () => {
+    try {
+      const user = cookies.get('userid');
+      const [altsRes, mythicRes, professionsRes, addonRes] = await Promise.all([
+        axios.get(config.url.API_URL + '/api/profile/alts/', {
+          params: {
+            user,
+            fields: [
+              'alt_id',
+              'alt_name',
+              'alt_realm',
+              'alt_realm_slug',
+              'alt_level',
+              'get_alt_race_display',
+              'get_alt_class_display',
+              'alt_faction',
+              'alt_ilvl',
+            ],
+          },
+        }),
+        axios.get(config.url.API_URL + '/api/profile/altmythicplus/', { params: { user } }),
+        axios.get(config.url.API_URL + '/api/profile/altprofessions/', {
+          params: {
+            user,
+            fields: ['.alt_id', 'get_profession_1_display', 'get_profession_2_display'],
+          },
+        }),
+        axios.get(config.url.API_URL + '/api/profile/users/', { params: { user, page: 'addon' } }),
+      ]);
+
+      const sortedAlts = (altsRes.data as RawAltRow[])
+        .map(parseAlt)
+        .sort((a, b) => b.level - a.level || b.ilvl - a.ilvl);
+      setAlts(sortedAlts);
+      setMythicByAlt(
+        new Map((mythicRes.data as MythicPlusEntry[]).map((m) => [m.alt, m.mythic_rating]))
+      );
+      setProfessionsByAlt(
+        new Map(
+          (professionsRes.data as [number, string, string][]).map(([altId, p1, p2]) => [
+            altId,
+            [p1, p2],
+          ])
+        )
+      );
+      setAddonByAlt(
+        new Map(
+          (addonRes.data as RawAddonAltData[]).map((a) => [
+            a.alt_id,
+            { gold: a.gold, playedTimeTotal: a.played_time_total },
+          ])
+        )
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load data.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    async function getData() {
-      try {
-        const user = cookies.get('userid');
-        const [altsRes, mythicRes, professionsRes] = await Promise.all([
-          axios.get(config.url.API_URL + '/api/profile/alts/', {
-            params: {
-              user,
-              fields: [
-                'alt_id',
-                'alt_name',
-                'alt_realm',
-                'alt_realm_slug',
-                'alt_level',
-                'get_alt_race_display',
-                'get_alt_class_display',
-                'alt_faction',
-                'alt_ilvl',
-              ],
-            },
-          }),
-          axios.get(config.url.API_URL + '/api/profile/altmythicplus/', { params: { user } }),
-          axios.get(config.url.API_URL + '/api/profile/altprofessions/', {
-            params: {
-              user,
-              fields: ['.alt_id', 'get_profession_1_display', 'get_profession_2_display'],
-            },
-          }),
-        ]);
-
-        const sortedAlts = (altsRes.data as RawAltRow[])
-          .map(parseAlt)
-          .sort((a, b) => b.level - a.level || b.ilvl - a.ilvl);
-        setAlts(sortedAlts);
-        setMythicByAlt(
-          new Map((mythicRes.data as MythicPlusEntry[]).map((m) => [m.alt, m.mythic_rating]))
-        );
-        setProfessionsByAlt(
-          new Map(
-            (professionsRes.data as [number, string, string][]).map(([altId, p1, p2]) => [
-              altId,
-              [p1, p2],
-            ])
-          )
-        );
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load data.');
-      } finally {
-        setLoading(false);
-      }
-    }
     getData();
-  }, []);
+  }, [getData]);
 
   return (
     <PageLayout title="Account">
+      <div className="mb-4">
+        <AddonFileUpload
+          inputKey={uploadKey}
+          onChange={() => {
+            setUploadKey((k) => k + 1);
+            getData();
+          }}
+        />
+      </div>
       {loading && <LoadingSpinner />}
       {error && <p className="text-red-400 text-sm">{error}</p>}
       {!loading && !error && (
-        <AccountTable alts={alts} mythicByAlt={mythicByAlt} professionsByAlt={professionsByAlt} />
+        <AccountTable
+          alts={alts}
+          mythicByAlt={mythicByAlt}
+          professionsByAlt={professionsByAlt}
+          addonByAlt={addonByAlt}
+        />
       )}
     </PageLayout>
   );


### PR DESCRIPTION
## Summary
- Renamed `KeybindUpload` to `AddonFileUpload` (it's a generic `.lua` upload widget) and mounted it on the Account page above `AccountTable`.
- `Account.tsx` joins the new `page=addon` backend endpoint into `AccountTable`, which gains Gold and Played Time columns (formatted via new `formatGold`/`formatPlayedTime` helpers in `format.ts`).
- Replaced `Header`'s manual Update button with a silent hourly auto-scan triggered on mount when `lastupdate` is missing or more than an hour old.

## Test plan
- [x] `tsc --noEmit`
- [x] `oxlint src/`
- [x] `npm test -- --watchAll=false` (12 passed)
- [x] `npm run build`