### PR TITLE
Fetch addon data from altaddondata instead of page=addon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Absolute imports are configured via `baseUrl: "src"` in `tsconfig.json`, so impo
 
 **Data slicing in Mount/Pet**: the API appends count metadata at the end of the response array. `data.slice(0, -3)` passes actual records to the table; `data.slice(-3)` retrieves the counts.
 
-**Addon file upload**: users upload a `.lua` file (WoW addon export) via `AddonFileUpload`, mounted above `AccountTable` on the Account page, which PUTs it to the backend as `multipart/form-data`. `Account.tsx` joins the parsed gold/played-time data (`/api/profile/users/?page=addon`) into `AccountTable`'s Gold and Played Time columns — `'—'` when an alt hasn't appeared in an uploaded file yet. Currencies/lockouts/keystone/vault are captured by the addon but not yet surfaced (same join pattern, not built).
+**Addon file upload**: users upload a `.lua` file (WoW addon export) via `AddonFileUpload`, mounted above `AccountTable` on the Account page, which PUTs it to the backend as `multipart/form-data`. The backend parses it on upload and stores gold/played-time in `ProfileAltAddonData`; `Account.tsx` fetches `/api/profile/altaddondata/` and joins it into `AccountTable`'s Gold and Played Time columns — `'—'` when an alt hasn't appeared in an uploaded file yet. Currencies/lockouts/keystone/vault are captured by the addon but not yet surfaced (same join pattern, not built).
 
 ### Styling
 

--- a/src/pages/Account.test.tsx
+++ b/src/pages/Account.test.tsx
@@ -33,7 +33,7 @@ test('renders alt data on success', async () => {
   mockedAxios.get.mockImplementation((url: string) => {
     if (url.includes('/altmythicplus/')) return Promise.resolve({ data: [] });
     if (url.includes('/altprofessions/')) return Promise.resolve({ data: [] });
-    if (url.includes('/api/profile/users/')) return Promise.resolve({ data: [] });
+    if (url.includes('/api/profile/altaddondata/')) return Promise.resolve({ data: [] });
     return Promise.resolve({
       data: [[1, 'Testchar', 'Stormrage', 'stormrage', 70, 'Human', 'Warrior', 'Alliance', 615]],
     });

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -69,7 +69,7 @@ function Account() {
             fields: ['.alt_id', 'get_profession_1_display', 'get_profession_2_display'],
           },
         }),
-        axios.get(config.url.API_URL + '/api/profile/users/', { params: { user, page: 'addon' } }),
+        axios.get(config.url.API_URL + '/api/profile/altaddondata/', { params: { user } }),
       ]);
 
       const sortedAlts = (altsRes.data as RawAltRow[])


### PR DESCRIPTION
## Summary
- Switches the Account page's gold/played-time fetch from `/api/profile/users/?page=addon` to `/api/profile/altaddondata/`, matching the backend's move to a real DB-backed endpoint (`ProfileAltAddonData`) instead of re-parsing the raw addon file on every read.

## Test plan
- [x] `tsc --noEmit`
- [x] `oxlint src/`
- [x] `npm test -- --watchAll=false` (12 passed)